### PR TITLE
integrate docker and gh-pages deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ jobs:
         - cd react-app
       install:
         - npm install
-      cache:
-        directories:
-          - 'node_modules'
       script:
         - echo "Run react-app testing"
         - npm run build
@@ -32,22 +29,25 @@ jobs:
     #     - echo "Run express-app testing"
     #     - npm run test
 
-    - stage: deploy-to-heroku
+    - stage: deploy-to-gh-pages
+      before_install:
+        - cd react-app
+      install:
+        - npm install
+      cache:
+        directories:
+          - 'build'
       script:
         - npm run build
-        - cd express-app
-      before_deploy:
-        - grep -vwE "^build$" .gitignore > .gitignore.build
-        - mv .gitignore.build .gitignore
       deploy:
         skip_cleanup: true
-        provider: heroku
-        edge: true
-        app: rctech-owl
-        api_key: $HEROKU_API_KEY
+        provider: pages
+        github_token: $GITHUB_TOKEN
+        keep_history: true
+        local_dir: './react-app/build'
         on:
           all_branches: true
           # condition: $TRAVIS_BRANCH =~ ^(master|testing)$
 
-    - stage: test-heroku
-      script: curl https://rctech-owl.herokuapp.com/
+    - stage: test-deploy
+      script: curl https://owl.rctech.club

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,22 @@ jobs:
           all_branches: true
           # condition: $TRAVIS_BRANCH =~ ^(master|testing)$
 
+    - stage: deploy-to-heroku
+      script:
+        - npm run build
+        - cd express-app
+      before_deploy:
+        - grep -vwE "^build$" .gitignore > .gitignore.build
+        - mv .gitignore.build .gitignore
+      deploy:
+        skip_cleanup: true
+        provider: heroku
+        edge: true
+        app: rctech-owl
+        api_key: $HEROKU_API_KEY
+        on:
+          all_branches: true
+          # condition: $TRAVIS_BRANCH =~ ^(master|testing)$
+
     - stage: test-deploy
       script: curl https://owl.rctech.club

--- a/react-app/.dockerignore
+++ b/react-app/.dockerignore
@@ -1,0 +1,15 @@
+# node modules
+node_modules/
+
+# react builds
+build/
+
+# environment variables
+.env*
+
+# git
+.gitignore
+.git
+
+# documentation
+*.md

--- a/react-app/Dockerfile
+++ b/react-app/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:latest
+WORKDIR /app
+COPY . /app
+RUN ["npm", "install", "--silent"]
+
+# expose web pack server
+EXPOSE 3000
+
+CMD ["npm", "run", "start"]

--- a/react-app/README.md
+++ b/react-app/README.md
@@ -1,68 +1,51 @@
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+# React Frontend
 
-## Available Scripts
+### Running a local development environment
 
-In the project directory, you can run:
+Clone this repository, and navigate to `react-app` directory.
 
-### `npm start`
+`cd react-app`
 
-Runs the app in the development mode.<br>
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+Install node packages using npm.
 
-The page will reload if you make edits.<br>
-You will also see any lint errors in the console.
+`npm install`
 
-### `npm test`
+Start the development server.
 
-Launches the test runner in the interactive watch mode.<br>
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+`npm run start`
 
-### `npm run build`
+### Test driving the application
 
-Builds the app for production to the `build` folder.<br>
-It correctly bundles React in production mode and optimizes the build for the best performance.
+##### Using Docker and without cloning our Github repository
 
-The build is minified and the filenames include the hashes.<br>
-Your app is ready to be deployed!
+Pull our public repository at Docker hub.
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+`docker run --name owl --rm -p 3000:3000 rctechclub/owl:dev`
 
-### `npm run eject`
+- `-d` enables terminal detached mode (optional)
+- `--name` sets a short name for the docker container
+- `--rm` removes the docker container if a stop command is executed
+- `-p 3000:3000` plugs the container's port from 3000 to 3000
 
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
+Now, you may navigate to `localhost:3000`.
 
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+Stop the container by either
 
-Instead, it will copy all the configuration files and the transitive dependencies (Webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
+- `CTRL + C` if you run without `-d`
+- `docker stop owl` if you run with `-d`
 
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+Remove the image if necessary.
 
-## Learn More
+`docker rmi rctechclub/owl:dev`
 
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
+**Note that this does not enable hot reloading**
 
-To learn React, check out the [React documentation](https://reactjs.org/).
+### Docker Build and Push
 
-### Code Splitting
+To build an image.
 
-This section has moved here: https://facebook.github.io/create-react-app/docs/code-splitting
+`npm run docker:build`
 
-### Analyzing the Bundle Size
+To push to public repository – only for those who are part of the rctechclub organisation on Docker hub.
 
-This section has moved here: https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size
-
-### Making a Progressive Web App
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app
-
-### Advanced Configuration
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/advanced-configuration
-
-### Deployment
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/deployment
-
-### `npm run build` fails to minify
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify
+`npm run docker:push`

--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -4827,6 +4827,12 @@
         "minimalistic-crypto-utils": "^1.0.0"
       }
     },
+    "email-addresses": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.0.3.tgz",
+      "integrity": "sha512-kUlSC06PVvvjlMRpNIl3kR1NRXLEe86VQ7N0bQeaCZb2g+InShCeHQp/JvyYNTugMnRN2NvJhHlc3q12MWbbpg==",
+      "dev": true
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -5778,6 +5784,33 @@
         "schema-utils": "^1.0.0"
       }
     },
+    "filename-reserved-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
+      "integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
+      "dev": true
+    },
+    "filenamify": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
+      "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
+      "dev": true,
+      "requires": {
+        "filename-reserved-regex": "^1.0.0",
+        "strip-outer": "^1.0.0",
+        "trim-repeated": "^1.0.0"
+      }
+    },
+    "filenamify-url": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-1.0.0.tgz",
+      "integrity": "sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=",
+      "dev": true,
+      "requires": {
+        "filenamify": "^1.0.0",
+        "humanize-url": "^1.0.0"
+      }
+    },
     "filesize": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
@@ -6126,6 +6159,52 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "gh-pages": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-2.1.1.tgz",
+      "integrity": "sha512-yNW2SFp9xGRP/8Sk2WXuLI/Gn92oOL4HBgudn6PsqAnuWT90Y1tozJoTfX1WdrDSW5Rb90kLVOf5mm9KJ/2fDw==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.1",
+        "commander": "^2.18.0",
+        "email-addresses": "^3.0.1",
+        "filenamify-url": "^1.0.0",
+        "fs-extra": "^7.0.0",
+        "globby": "^6.1.0",
+        "graceful-fs": "^4.1.11",
+        "rimraf": "^2.6.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "glob": {
@@ -6604,6 +6683,46 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
+    "humanize-url": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-1.0.1.tgz",
+      "integrity": "sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=",
+      "dev": true,
+      "requires": {
+        "normalize-url": "^1.0.0",
+        "strip-url-auth": "^1.0.0"
+      },
+      "dependencies": {
+        "normalize-url": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+          "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.0.1",
+            "prepend-http": "^1.0.0",
+            "query-string": "^4.1.0",
+            "sort-keys": "^1.0.0"
+          }
+        },
+        "query-string": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+          "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+          "dev": true
+        }
+      }
+    },
     "hyphenate-style-name": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
@@ -6946,6 +7065,12 @@
       "requires": {
         "path-is-inside": "^1.0.1"
       }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -10742,6 +10867,12 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
     "prettier": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
@@ -12444,6 +12575,15 @@
         }
       }
     },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
+    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -12829,6 +12969,21 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
       "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
     },
+    "strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
+      }
+    },
+    "strip-url-auth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-url-auth/-/strip-url-auth-1.0.1.tgz",
+      "integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=",
+      "dev": true
+    },
     "style-loader": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.0.0.tgz",
@@ -13140,6 +13295,15 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
       }
     },
     "trim-right": {

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -29,7 +29,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "deploy": "npm run build && gh-pages -d build"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -47,6 +48,7 @@
     ]
   },
   "devDependencies": {
+    "gh-pages": "^2.1.1",
     "prettier": "^1.18.2"
   }
 }

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -30,7 +30,9 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "deploy": "npm run build && gh-pages -d build"
+    "deploy": "npm run build && gh-pages -d build",
+    "docker:build": "docker build -t rctechclub/owl:dev .",
+    "docker:push": "docker push rctechclub/owl:dev"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/react-app/public/CNAME
+++ b/react-app/public/CNAME
@@ -1,0 +1,1 @@
+owl.rctech.club

--- a/react-app/public/manifest.json
+++ b/react-app/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "short_name": "HaBoS",
+  "short_name": "Owl",
   "name": "RC Lee Hall Booking System",
   "icons": [
     {

--- a/react-app/src/App.js
+++ b/react-app/src/App.js
@@ -12,7 +12,7 @@ const App = () => {
   if (!window.location.host.includes('localhost')) {
     localStorage.setItem('id', qs.parse(window.location.search).id || '');
     if (localStorage.getItem('id') === '') {
-      const app_url = 'rctech-owl.herokuapp.com';
+      const app_url = 'owl.rctech.club';
       window.location.replace(
         `https://ladybird.rctech.club/?redirectTo=${app_url}`
       );

--- a/react-app/src/components/main/ChooseTime.js
+++ b/react-app/src/components/main/ChooseTime.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import Timetable from 'react-timetable-events';
 import NavBar from '../complement/NavBar.js';
+import getRooms from '../../functions/getRooms';
 const moment = require('moment');
-const getRooms = require('../../functions/getRooms');
 
 const style = {
   container: {

--- a/react-app/src/functions/getRooms.js
+++ b/react-app/src/functions/getRooms.js
@@ -11,7 +11,7 @@ const getRooms = async (room, date) => {
         .format('ll')
     ] = [];
   }
-  const url = 'http://rctech-owl-dev.herokuapp.com/api/room';
+  const url = 'https://rctech-owl-dev.herokuapp.com/api/room';
   const response = await axios.get(url);
   const rooms = response.data.rooms;
   let times = undefined;
@@ -41,4 +41,4 @@ const getRooms = async (room, date) => {
   }
 };
 
-module.exports = getRooms;
+export default getRooms;


### PR DESCRIPTION
Closes #42 

Docker: 
hot-reloading does not work on instances spun up by docker images, it doesn't make much sense doing that anyways, I feel

gh-pages:
travis now deploys on gh-pages on a rolling basis along with heroku
gh-pages hosted url is at: https://owl.rctech.club
heroku hosted url is at: rctech-owl.herokuapp.com
heroku deploys will be deprecated through issue #32 

readme documentation within `react-app` has been re-written to reflect these changes too