### PR TITLE
fix auth id storage bug

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,11 @@ import ChooseTime from './components/main/ChooseTime';
 import BookingSummary from './components/main/BookingSummary';
 
 const App = () => {
-  localStorage.setItem('id', qs.parse(window.location.search).id || '');
+  // make sure that id gets stored correctly first before running anything else
+  if (localStorage.getItem('id') === '') {
+    localStorage.setItem('id', qs.parse(window.location.search).id || '');
+  }
+
   if (localStorage.getItem('id') === '') {
     const app_url = 'owl.rctech.club';
     let url = `https://ladybird.rctech.club/?redirectTo=${app_url}`;


### PR DESCRIPTION
closes #52 

please replicate current `master` branch and this `auth-bug` branch in your machine to test it out first, do a comparison between the two branches

this PR aims to solve a situation in `master` where I send a graphql query in `App.js`, it would return a `no jwt token provided` error (indicating a failure of `localStorage` getting the `id` key), which is weird because the url string does contain the `id` parameter, and using chrome dev tools tells me that the `id` key got stored in `localStorage` correctly. The problem fixes itself when I refresh the web page, so I assume there is a delay between `localStorage` setting and getting keys.