### PR TITLE
Fix bug and change default export

### DIFF
--- a/src/components/main/ChooseTime.js
+++ b/src/components/main/ChooseTime.js
@@ -7,7 +7,7 @@ import getRooms from '../../functions/getRooms';
 import moment from 'moment';
 import { makeStyles } from '@material-ui/core';
 import Typography from '@material-ui/core/Typography';
-import validateTime from '../../functions/validateTime';
+import { validateTime } from '../../functions/validateTime';
 import { useQuery } from '@apollo/react-hooks';
 import { ROOM_BOOKINGS } from '../../gql/bookings';
 import { TimeChooserPanel } from '../ChooseTime/TimeChooserPanel';

--- a/src/functions/validateTime.js
+++ b/src/functions/validateTime.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-const validateTime = (timeSlots, date, start, end) => {
+export const validateTime = (timeSlots, date, start, end) => {
   const startTime = moment(date)
     .hours(Number(moment(start).format('HH')))
     .startOf('hour');
@@ -14,9 +14,10 @@ const validateTime = (timeSlots, date, start, end) => {
     alert('Maximum hours of booking per person is 2 hours.');
     return false;
   } else if (
-    startTime.isSameOrBefore(dateChosen.hour(Number(moment().format('HH'))))
+    startTime.isSameOrBefore(dateChosen.hour(Number(moment().format('HH')))) &&
+    startTime.isSame(moment(), 'day')
   ) {
-    alert('Selected timeslot is not available');
+    alert('Selected timeslot is not available.');
     return false;
   } else if (
     !(
@@ -28,7 +29,10 @@ const validateTime = (timeSlots, date, start, end) => {
     return false;
   } else {
     for (let i = 0; i < timeSlots.length; ++i) {
-      if (timeSlots[i].startTime.isSame(startTime, 'hour')) {
+      if (
+        timeSlots[i].startTime.isSame(startTime, 'hour') ||
+        timeSlots[i].endTime.isSame(endTime, 'hour')
+      ) {
         alert('Timeslot has been booked by someone else.');
         return false;
       }
@@ -36,5 +40,3 @@ const validateTime = (timeSlots, date, start, end) => {
   }
   return true;
 };
-
-export default validateTime;


### PR DESCRIPTION
I noticed there is a couple of minor bugs in the validateTime function. 

- Users shouldn't be able to book passed timeslot **if date of booking is the same as current date only**. 

- Booked timeslot checking should be done on **both startTime and endTime sides**.

Both are fixed.